### PR TITLE
Improve workflow for building the website

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,3 +1,7 @@
+# SPDX-Copyright: Free Software Foundation Europe e.V.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 pipeline:
   syntaxcheck:
     image: monachus/hugo

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 
 site/public/
 site/content/practices
+site/public/

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@
 
 site/public/
 site/content/practices
-site/public/

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 # SPDX-License-Identifier: CC0-1.0
 
 site/public/
+site/content/practices

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,10 @@ ADD https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/${HUGO_B
 RUN dpkg -i /tmp/hugo.deb && \
     rm /tmp/hugo.deb
 
-COPY ./site /tmp/reuse-web/
+COPY . /tmp/reuse-website
 
-# copy markdown files from submodule
-COPY ./reuse-docs/practices /tmp/reuse-web/content/practices
+RUN /tmp/reuse-website/sync-docs.sh
 
-# copy generated PDF files from reuse-docs' shared volume, build website, and run apache
-CMD cp /tmp/pdf/*.pdf /tmp/reuse-web/static/ && \
-    hugo -s /tmp/reuse-web -d /var/www/html && \
-    apache2-foreground
+RUN hugo -s /tmp/reuse-website/site -d /var/www/html
+
+CMD apache2-foreground

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
+# SPDX-Copyright: Free Software Foundation Europe e.V.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 FROM php:7-apache
 
-ENV HUGO_VERSION 0.54.0
+ENV HUGO_VERSION 0.55.6
 ENV HUGO_BINARY hugo_${HUGO_VERSION}_Linux-64bit.deb
 
 ADD https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/${HUGO_BINARY} /tmp/hugo.deb

--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@ for more automation.
 
 ## Install
 
+Before doing anything, run the following command to download the documentation
+as submodule:
+
+```
+git submodule update --init
+```
+
 There's no installation here, but you may try running `hugo` in the
 `site/` directory to generate the website when testing locally.
 Typically, we let our Drone CI build and deploy the website for us.

--- a/README.md
+++ b/README.md
@@ -12,11 +12,13 @@ for more automation.
 
 ## Install
 
-Before doing anything, run the following command to download the documentation
-as submodule:
+Before doing anything, run the following commands to download the documentation
+as submodule, and to synchronise the contents of the submodule into the `site/`
+directory:
 
 ```
 git submodule update --init
+bash sync-docs.sh
 ```
 
 There's no installation here, but you may try running `hugo` in the

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,5 @@
 version: '3'
 services:
-  reuse-docs:
-    container_name: reuse-docs
-    build:
-      context: ./reuse-docs
-    image: reuse-docs
-    volumes:
-      - /srv/reuse/docs/pdf:/tmp/pdf:rw
 
   reuse-web:
     container_name: reuse-web
@@ -15,8 +8,6 @@ services:
     restart: always
     volumes:
       - /srv/reuse/docs/pdf:/tmp/pdf:ro
-    depends_on:
-      - reuse-docs
     logging:
       driver: json-file
       options:

--- a/site/config.toml
+++ b/site/config.toml
@@ -1,5 +1,5 @@
-baseurl         = "https://reuse.software"
-languageCode    = "en-us"
+baseURL         = "https://reuse.software/"
+languageCode    = "en"
 title           = "REUSE Initiative"
 theme           = "github-project-landing-page"
 

--- a/site/themes/github-project-landing-page/layouts/partials/head.html
+++ b/site/themes/github-project-landing-page/layouts/partials/head.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="">
     <meta name="author" content="">
-    <base href="{{ .Site.BaseURL }}">
     <title>{{ .Title }}</title>
 
     <!-- Bootstrap Core CSS -->

--- a/site/themes/github-project-landing-page/layouts/partials/nav.html
+++ b/site/themes/github-project-landing-page/layouts/partials/nav.html
@@ -9,7 +9,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a class="page-scroll navbar-brand" href="#intro">{{ .Site.Title }}</a>
+            <a class="page-scroll navbar-brand" href="{{ "/" | relLangURL }}">{{ .Site.Title }}</a>
         </div>
         <!-- Collect the nav links, forms, and other content for toggling -->
         <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">

--- a/sync-docs.sh
+++ b/sync-docs.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# SPDX-Copyright: Free Software Foundation Europe e.V.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This script synchronises all markdown directories from the reuse-docs
+# submodule into the site directory.
+
+cd $(dirname $0)
+
+rm -fr site/content/practices
+cp -r reuse-docs/practices site/content/practices


### PR DESCRIPTION
Now that reuse-docs and reuse-website are two separate repositories, there is some added difficulty in working on them.

This PR hopes to fix that a bit. I set out to make it easy to build the website locally using Hugo, which can now be achieved with the following workflow:

```
git submodule update --init
bash sync-docs.sh
cd site/
hugo
```
As a consequence of this, I figured I might as well change the Dockerfile to use this workflow, too. I got it working running `docker build .`. The `docker-compose.yml` file seems unnecessary to me now, because I moved everything into a single container.

This PR does NOT currently build the PDFs, though it should be fairly trivial to implement that (just copy some stuff over from the Dockerfile in reuse-docs). The reason I didn't implement that is because I'm lazy, and we won't keep the old spec around for much longer, anyway.

As a consequence of that, this PR should NOT be merged. Instead, consider this branch a development branch for further changes.

If you would rather merge this new workflow now, we simply need to build the PDFs in this repository. I can do that fairly easily.

The Dockerfile in reuse-docs can be removed if this new workflow is merged. This is a Good Thing™, because it would turn that repository purely into a project containing raw Markdown files, whereas this repository (reuse-website) would contain the logic and structure to support those raw files.