### PR TITLE
Make tutorial show tool instructions

### DIFF
--- a/site/config.toml
+++ b/site/config.toml
@@ -8,6 +8,10 @@ title           = "REUSE"
 theme           = "github-project-landing-page"
 sectionPagesMenu = "main"
 
+[markup.highlight]
+codeFences = true
+style = "emacs"
+
 #[permalinks]
 #        page = "/:title/"
 #        about = "/:filename/"

--- a/site/layouts/shortcodes/box-tool.html
+++ b/site/layouts/shortcodes/box-tool.html
@@ -1,0 +1,19 @@
+<!--
+  SPDX-License-Identifier: MIT
+  SPDX-FileCopyrightText: 2020 Free Software Foundation Europe e.V. <https://fsfe.org>
+-->
+{{- $id := md5 .Inner -}}
+<div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
+  <div class="panel panel-default" id="toc">
+    <div class="panel-heading" role="tab" id="headingOne">
+        <a class="collapsed" role="button" data-toggle="collapse" data-parent="#accordion" href="#{{ $id }}" aria-expanded="false" aria-controls="collapseOne">
+          <h4 class="panel-title">Tool instructions for this step</h4>
+        </a>
+    </div>
+    <div id="{{ $id }}" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingOne">
+      <div class="panel-body">
+          {{ .Inner | markdownify }}
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
This PR is closely connected to https://github.com/fsfe/reuse-docs/pull/55 which adds the instructions on the docs side.

In this branch, I prepared the website layout and made the submodule point to the changed reuse-docs