### PR TITLE
Version bump in instructions

### DIFF
--- a/site/content/en/dev.md
+++ b/site/content/en/dev.md
@@ -46,7 +46,7 @@ You can automatically run `reuse lint` on every commit as a pre-commit hook for 
 ```yaml
 repos:
 -   repo: https://github.com/fsfe/reuse-tool
-    rev: v1.0.0
+    rev: v2.1.0
     hooks:
     - id: reuse
 ```


### PR DESCRIPTION
The installation instructions recommended installing an outdated version of reuse. This was causing an exception (see below). Solution: bump version - no more exception.

```
Traceback (most recent call last):
  File "/home/user/.cache/pre-commit/repowp2da061/py_env-python3/bin/reuse", line 5, in <module>
    from reuse._main import main
  File "/home/user/.cache/pre-commit/repowp2da061/py_env-python3/lib/python3.12/site-packages/reuse/__init__.py", line 15, in <module>
    from pkg_resources import DistributionNotFound, get_distribution
ModuleNotFoundError: No module named 'pkg_resources'
```