### PR TITLE
Include active language in hrefs in navbar

### DIFF
--- a/site/layouts/partials/nav.html
+++ b/site/layouts/partials/nav.html
@@ -25,7 +25,7 @@
               {{- $rel := .RelPermalink -}}
               {{- range .Site.Menus.main -}}
                 <!-- if RelPermalink = this menu item, mark it -->
-                <li class="{{if strings.HasSuffix $rel .URL }}active{{end}}"><a href="{{ .URL }}">{{ i18n (delimit (slice "menu_" .Identifier) "") }}</a></li>
+                <li class="{{if strings.HasSuffix $rel .URL }}active{{end}}"><a href="{{ .URL | relLangURL }}">{{ i18n (delimit (slice "menu_" .Identifier) "") }}</a></li>
               {{- end -}}
             </ul>
         </div>


### PR DESCRIPTION
DO NOT MERGE

As-is:

1. Activate a non-English language
2. Click on FAQ in the navbar
3. You get the English-language FAQ and have to switch language again

To-be:

1. Activate a non-English language
2. Click on FAQ in the navbar
3. You get the selected non-English-language FAQ

However, this PR has one big problem:

If the FAQ is translated for your language, but the specification is not, then clicking on the specification results in a 404.

In general, the way translations work isn't perfect. This needs some workshopping.