### PR TITLE
Switched from `addHeader` to `annotate` in the tutorial

### DIFF
--- a/site/content/en/tutorial.md
+++ b/site/content/en/tutorial.md
@@ -113,16 +113,16 @@ header information, but of course with corresponding comment syntax.
 
 {{< box-tool >}}
 
-The `reuse addheader` command helps with adding licensing and copyright
+The `reuse annotate` command helps with adding licensing and copyright
 information to your files. For the task above, the following command
 would do the job:
 
 ```bash
-reuse addheader --copyright="Jane Doe <jane@example.com>" --license="GPL-3.0-or-later" src/main.c Makefile README.md
+reuse annotate --copyright="Jane Doe <jane@example.com>" --license="GPL-3.0-or-later" src/main.c Makefile README.md
 ```
 
 Please see the [tool's documentation about
-addheader](https://reuse.readthedocs.io/en/stable/usage.html#addheader)
+annotate](https://reuse.readthedocs.io/en/stable/usage.html#annotate)
 for more options like comment styles and templates
 
 {{< /box-tool >}}
@@ -144,11 +144,11 @@ The REUSE helper tool should automatically detect binary files and
 therefore automatically create a corresponding `.license` file.
 
 If it does not, or if you would like to enforce this, add the
-`--force-dot-license` argument to the addheader command. So the command
+`--force-dot-license` argument to the annotate command. So the command
 for the above task may look like this:
 
 ```bash
-reuse addheader --copyright="Jane Doe <jane@example.com>" --license="GPL-3.0-or-later" --force-dot-license img/cat.jpg img/dog.jpg
+reuse annotate --copyright="Jane Doe <jane@example.com>" --license="GPL-3.0-or-later" --force-dot-license img/cat.jpg img/dog.jpg
 ```
 
 {{< /box-tool >}}
@@ -175,7 +175,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 The tool as of now does not provide a way to replace existing
 REUSE-compliant copyright and licensing information. A run of
-the `addheader` command would not replace but extend the `.license`
+the `annotate` command would not replace but extend the `.license`
 files with two additional lines stating the copyright of Max Mehl and
 the CC-BY-4.0 license. So you would have to update these manually.
 
@@ -218,10 +218,10 @@ More information about copyrightable files can be found in the [REUSE FAQ]({{< r
 
 {{< box-tool >}}
 
-As before, a combination of the `addheader` and `download` commands will fulfil the above step:
+As before, a combination of the `annotate` and `download` commands will fulfil the above step:
 
 ```bash
-reuse addheader --copyright="Jane Doe <jane@example.com>" --license="CC0-1.0" .gitignore
+reuse annotate --copyright="Jane Doe <jane@example.com>" --license="CC0-1.0" .gitignore
 
 reuse download --all
 ```

--- a/site/po/cs.po
+++ b/site/po/cs.po
@@ -2575,30 +2575,30 @@ msgstr ""
 #. type: Plain text
 #: site/content/en/tutorial.md
 msgid ""
-"The `reuse addheader` command helps with adding licensing and copyright "
+"The `reuse annotate` command helps with adding licensing and copyright "
 "information to your files. For the task above, the following command would "
 "do the job:"
 msgstr ""
-"Příkaz `reuse addheader` vám pomůže přidat do souborů informace o licencích "
+"Příkaz `reuse annotate` vám pomůže přidat do souborů informace o licencích "
 "a autorských právech. Pro výše uvedenou úlohu by tuto úlohu splnil "
 "následující příkaz:"
 
 #. type: Fenced code block (bash)
 #: site/content/en/tutorial.md
 #, no-wrap
-msgid "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
-msgstr "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
+msgstr "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
 
 #. type: Plain text
 #: site/content/en/tutorial.md
 msgid ""
-"Please see the [tool's documentation about addheader](https://reuse."
-"readthedocs.io/en/stable/usage.html#addheader)  for more options like "
+"Please see the [tool's documentation about annotate](https://reuse."
+"readthedocs.io/en/stable/usage.html#annotate)  for more options like "
 "comment styles and templates"
 msgstr ""
 "Další možnosti, například styly komentářů a šablony, naleznete v dokumentaci "
-"[nástroje addheader](https://reuse.readthedocs.io/en/stable/usage."
-"html#addheader)"
+"[nástroje annotate](https://reuse.readthedocs.io/en/stable/usage."
+"html#annotate)"
 
 #. type: Title ###
 #: site/content/en/tutorial.md
@@ -2646,23 +2646,23 @@ msgstr ""
 #, fuzzy
 #| msgid ""
 #| "If it does not, or if you would like to enforce this, add the `--explicit-"
-#| "license` argument to the addheader command. So the command for the above "
+#| "license` argument to the annotate command. So the command for the above "
 #| "task may look like this:"
 msgid ""
 "If it does not, or if you would like to enforce this, add the `--force-dot-"
-"license` argument to the addheader command. So the command for the above "
+"license` argument to the annotate command. So the command for the above "
 "task may look like this:"
 msgstr ""
 "Pokud tomu tak není, nebo pokud chcete tuto povinnost vynutit, přidejte do "
-"příkazu addheader argument `--explicit-license`. Příkaz pro výše uvedenou "
+"příkazu annotate argument `--explicit-license`. Příkaz pro výše uvedenou "
 "úlohu tedy může vypadat takto:"
 
 #. type: Fenced code block (bash)
 #: site/content/en/tutorial.md
 #, fuzzy, no-wrap
-#| msgid "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
-msgid "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --force-dot-license img/cat.jpg img/dog.jpg\n"
-msgstr "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
+#| msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --force-dot-license img/cat.jpg img/dog.jpg\n"
+msgstr "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
 
 #. type: Title ###
 #: site/content/en/tutorial.md
@@ -2715,14 +2715,14 @@ msgstr ""
 #: site/content/en/tutorial.md
 msgid ""
 "The tool as of now does not provide a way to replace existing REUSE-"
-"compliant copyright and licensing information. A run of the `addheader` "
+"compliant copyright and licensing information. A run of the `annotate` "
 "command would not replace but extend the `.license` files with two "
 "additional lines stating the copyright of Max Mehl and the CC-BY-4.0 "
 "license. So you would have to update these manually."
 msgstr ""
 "Nástroj zatím neposkytuje způsob, jak nahradit stávající informace o "
 "autorských právech a licencích v souladu s nařízením REUSE. Spuštění příkazu "
-"`addheader` by nenahradilo, ale rozšířilo by soubory `.license` o dva další "
+"`annotate` by nenahradilo, ale rozšířilo by soubory `.license` o dva další "
 "řádky uvádějící autorská práva Maxe Mehla a licenci CC-BY-4.0. Ty byste tedy "
 "museli aktualizovat ručně."
 
@@ -2824,21 +2824,21 @@ msgstr ""
 #. type: Plain text
 #: site/content/en/tutorial.md
 msgid ""
-"As before, a combination of the `addheader` and `download` commands will "
+"As before, a combination of the `annotate` and `download` commands will "
 "fulfil the above step:"
 msgstr ""
-"Stejně jako dříve splní výše uvedený krok kombinace příkazů `addheader` a "
+"Stejně jako dříve splní výše uvedený krok kombinace příkazů `annotate` a "
 "`download`:"
 
 #. type: Fenced code block (bash)
 #: site/content/en/tutorial.md
 #, no-wrap
 msgid ""
-"reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
+"reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
 "\n"
 "reuse download --all\n"
 msgstr ""
-"reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
+"reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
 "\n"
 "reuse download --all\n"
 

--- a/site/po/de.po
+++ b/site/po/de.po
@@ -2392,7 +2392,7 @@ msgstr ""
 #. type: Plain text
 #: site/content/en/tutorial.md
 msgid ""
-"The `reuse addheader` command helps with adding licensing and copyright "
+"The `reuse annotate` command helps with adding licensing and copyright "
 "information to your files. For the task above, the following command would "
 "do the job:"
 msgstr ""
@@ -2400,14 +2400,14 @@ msgstr ""
 #. type: Fenced code block (bash)
 #: site/content/en/tutorial.md
 #, no-wrap
-msgid "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
 msgstr ""
 
 #. type: Plain text
 #: site/content/en/tutorial.md
 msgid ""
-"Please see the [tool's documentation about addheader](https://reuse."
-"readthedocs.io/en/stable/usage.html#addheader)  for more options like "
+"Please see the [tool's documentation about annotate](https://reuse."
+"readthedocs.io/en/stable/usage.html#annotate)  for more options like "
 "comment styles and templates"
 msgstr ""
 
@@ -2446,14 +2446,14 @@ msgstr ""
 #: site/content/en/tutorial.md
 msgid ""
 "If it does not, or if you would like to enforce this, add the `--force-dot-"
-"license` argument to the addheader command. So the command for the above "
+"license` argument to the annotate command. So the command for the above "
 "task may look like this:"
 msgstr ""
 
 #. type: Fenced code block (bash)
 #: site/content/en/tutorial.md
 #, no-wrap
-msgid "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --force-dot-license img/cat.jpg img/dog.jpg\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --force-dot-license img/cat.jpg img/dog.jpg\n"
 msgstr ""
 
 #. type: Title ###
@@ -2496,7 +2496,7 @@ msgstr ""
 #: site/content/en/tutorial.md
 msgid ""
 "The tool as of now does not provide a way to replace existing REUSE-"
-"compliant copyright and licensing information. A run of the `addheader` "
+"compliant copyright and licensing information. A run of the `annotate` "
 "command would not replace but extend the `.license` files with two "
 "additional lines stating the copyright of Max Mehl and the CC-BY-4.0 "
 "license. So you would have to update these manually."
@@ -2577,7 +2577,7 @@ msgstr ""
 #. type: Plain text
 #: site/content/en/tutorial.md
 msgid ""
-"As before, a combination of the `addheader` and `download` commands will "
+"As before, a combination of the `annotate` and `download` commands will "
 "fulfil the above step:"
 msgstr ""
 
@@ -2585,7 +2585,7 @@ msgstr ""
 #: site/content/en/tutorial.md
 #, no-wrap
 msgid ""
-"reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
+"reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
 "\n"
 "reuse download --all\n"
 msgstr ""

--- a/site/po/el.po
+++ b/site/po/el.po
@@ -2028,7 +2028,7 @@ msgstr ""
 #. type: Plain text
 #: site/content/en/tutorial.md
 msgid ""
-"The `reuse addheader` command helps with adding licensing and copyright "
+"The `reuse annotate` command helps with adding licensing and copyright "
 "information to your files. For the task above, the following command would "
 "do the job:"
 msgstr ""
@@ -2036,14 +2036,14 @@ msgstr ""
 #. type: Fenced code block (bash)
 #: site/content/en/tutorial.md
 #, no-wrap
-msgid "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
 msgstr ""
 
 #. type: Plain text
 #: site/content/en/tutorial.md
 msgid ""
-"Please see the [tool's documentation about addheader](https://reuse."
-"readthedocs.io/en/stable/usage.html#addheader)  for more options like "
+"Please see the [tool's documentation about annotate](https://reuse."
+"readthedocs.io/en/stable/usage.html#annotate)  for more options like "
 "comment styles and templates"
 msgstr ""
 
@@ -2082,14 +2082,14 @@ msgstr ""
 #: site/content/en/tutorial.md
 msgid ""
 "If it does not, or if you would like to enforce this, add the `--force-dot-"
-"license` argument to the addheader command. So the command for the above "
+"license` argument to the annotate command. So the command for the above "
 "task may look like this:"
 msgstr ""
 
 #. type: Fenced code block (bash)
 #: site/content/en/tutorial.md
 #, no-wrap
-msgid "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --force-dot-license img/cat.jpg img/dog.jpg\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --force-dot-license img/cat.jpg img/dog.jpg\n"
 msgstr ""
 
 #. type: Title ###
@@ -2132,7 +2132,7 @@ msgstr ""
 #: site/content/en/tutorial.md
 msgid ""
 "The tool as of now does not provide a way to replace existing REUSE-"
-"compliant copyright and licensing information. A run of the `addheader` "
+"compliant copyright and licensing information. A run of the `annotate` "
 "command would not replace but extend the `.license` files with two "
 "additional lines stating the copyright of Max Mehl and the CC-BY-4.0 "
 "license. So you would have to update these manually."
@@ -2213,7 +2213,7 @@ msgstr ""
 #. type: Plain text
 #: site/content/en/tutorial.md
 msgid ""
-"As before, a combination of the `addheader` and `download` commands will "
+"As before, a combination of the `annotate` and `download` commands will "
 "fulfil the above step:"
 msgstr ""
 
@@ -2221,7 +2221,7 @@ msgstr ""
 #: site/content/en/tutorial.md
 #, no-wrap
 msgid ""
-"reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
+"reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
 "\n"
 "reuse download --all\n"
 msgstr ""

--- a/site/po/eo.po
+++ b/site/po/eo.po
@@ -2075,7 +2075,7 @@ msgstr ""
 #. type: Plain text
 #: site/content/en/tutorial.md
 msgid ""
-"The `reuse addheader` command helps with adding licensing and copyright "
+"The `reuse annotate` command helps with adding licensing and copyright "
 "information to your files. For the task above, the following command would "
 "do the job:"
 msgstr ""
@@ -2083,14 +2083,14 @@ msgstr ""
 #. type: Fenced code block (bash)
 #: site/content/en/tutorial.md
 #, no-wrap
-msgid "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
-msgstr "reuse addheader --copyright=\"Johanino Umo <johanino@example.com>\" --license=\"GPL-3.0-or-later\" fonto/ĉefprogramo.c Makefile README.md\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
+msgstr "reuse annotate --copyright=\"Johanino Umo <johanino@example.com>\" --license=\"GPL-3.0-or-later\" fonto/ĉefprogramo.c Makefile README.md\n"
 
 #. type: Plain text
 #: site/content/en/tutorial.md
 msgid ""
-"Please see the [tool's documentation about addheader](https://reuse."
-"readthedocs.io/en/stable/usage.html#addheader)  for more options like "
+"Please see the [tool's documentation about annotate](https://reuse."
+"readthedocs.io/en/stable/usage.html#annotate)  for more options like "
 "comment styles and templates"
 msgstr ""
 
@@ -2132,16 +2132,16 @@ msgstr ""
 #: site/content/en/tutorial.md
 msgid ""
 "If it does not, or if you would like to enforce this, add the `--force-dot-"
-"license` argument to the addheader command. So the command for the above "
+"license` argument to the annotate command. So the command for the above "
 "task may look like this:"
 msgstr ""
 
 #. type: Fenced code block (bash)
 #: site/content/en/tutorial.md
 #, fuzzy, no-wrap
-#| msgid "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
-msgid "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --force-dot-license img/cat.jpg img/dog.jpg\n"
-msgstr "reuse addheader --copyright=\"Johanino Umo <johanino@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license bildo/kato.jpg bildo/hundo.jpg\n"
+#| msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --force-dot-license img/cat.jpg img/dog.jpg\n"
+msgstr "reuse annotate --copyright=\"Johanino Umo <johanino@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license bildo/kato.jpg bildo/hundo.jpg\n"
 
 #. type: Title ###
 #: site/content/en/tutorial.md
@@ -2187,7 +2187,7 @@ msgstr ""
 #: site/content/en/tutorial.md
 msgid ""
 "The tool as of now does not provide a way to replace existing REUSE-"
-"compliant copyright and licensing information. A run of the `addheader` "
+"compliant copyright and licensing information. A run of the `annotate` "
 "command would not replace but extend the `.license` files with two "
 "additional lines stating the copyright of Max Mehl and the CC-BY-4.0 "
 "license. So you would have to update these manually."
@@ -2268,7 +2268,7 @@ msgstr ""
 #. type: Plain text
 #: site/content/en/tutorial.md
 msgid ""
-"As before, a combination of the `addheader` and `download` commands will "
+"As before, a combination of the `annotate` and `download` commands will "
 "fulfil the above step:"
 msgstr ""
 
@@ -2276,7 +2276,7 @@ msgstr ""
 #: site/content/en/tutorial.md
 #, no-wrap
 msgid ""
-"reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
+"reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
 "\n"
 "reuse download --all\n"
 msgstr ""

--- a/site/po/es.po
+++ b/site/po/es.po
@@ -2626,29 +2626,29 @@ msgstr ""
 #. type: Plain text
 #: site/content/en/tutorial.md
 msgid ""
-"The `reuse addheader` command helps with adding licensing and copyright "
+"The `reuse annotate` command helps with adding licensing and copyright "
 "information to your files. For the task above, the following command would "
 "do the job:"
 msgstr ""
-"La orden `reuse addheader` ayuda a agregar información de licencia y "
+"La orden `reuse annotate` ayuda a agregar información de licencia y "
 "derechos de autor a sus archivos. Para la tarea anterior, haría el trabajo "
 "la siguiente orden:"
 
 #. type: Fenced code block (bash)
 #: site/content/en/tutorial.md
 #, no-wrap
-msgid "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
-msgstr "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-o-posterior\" src/main.c Makefile README.md\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
+msgstr "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-o-posterior\" src/main.c Makefile README.md\n"
 
 #. type: Plain text
 #: site/content/en/tutorial.md
 msgid ""
-"Please see the [tool's documentation about addheader](https://reuse."
-"readthedocs.io/en/stable/usage.html#addheader)  for more options like "
+"Please see the [tool's documentation about annotate](https://reuse."
+"readthedocs.io/en/stable/usage.html#annotate)  for more options like "
 "comment styles and templates"
 msgstr ""
-"Consulte la [documentación de la herramienta sobre addheader](https://reuse."
-"readthedocs.io/en/stable/usage.html#addheader)  para obtener más opciones, "
+"Consulte la [documentación de la herramienta sobre annotate](https://reuse."
+"readthedocs.io/en/stable/usage.html#annotate)  para obtener más opciones, "
 "como estilos de comentarios y plantillas"
 
 #. type: Title ###
@@ -2698,23 +2698,23 @@ msgstr ""
 #, fuzzy
 #| msgid ""
 #| "If it does not, or if you would like to enforce this, add the `--explicit-"
-#| "license` argument to the addheader command. So the command for the above "
+#| "license` argument to the annotate command. So the command for the above "
 #| "task may look like this:"
 msgid ""
 "If it does not, or if you would like to enforce this, add the `--force-dot-"
-"license` argument to the addheader command. So the command for the above "
+"license` argument to the annotate command. So the command for the above "
 "task may look like this:"
 msgstr ""
 "Si no es así, o si desea aplicar esto, agregue el argumento `--explicit-"
-"license` al comando addheader. Entonces, la orden para la tarea anterior se "
+"license` al comando annotate. Entonces, la orden para la tarea anterior se "
 "puede ver así:"
 
 #. type: Fenced code block (bash)
 #: site/content/en/tutorial.md
 #, fuzzy, no-wrap
-#| msgid "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
-msgid "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --force-dot-license img/cat.jpg img/dog.jpg\n"
-msgstr "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-o-posterior\" --explicit-license img/cat.jpg img/dog.jpg\n"
+#| msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --force-dot-license img/cat.jpg img/dog.jpg\n"
+msgstr "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-o-posterior\" --explicit-license img/cat.jpg img/dog.jpg\n"
 
 #. type: Title ###
 #: site/content/en/tutorial.md
@@ -2765,14 +2765,14 @@ msgstr ""
 #: site/content/en/tutorial.md
 msgid ""
 "The tool as of now does not provide a way to replace existing REUSE-"
-"compliant copyright and licensing information. A run of the `addheader` "
+"compliant copyright and licensing information. A run of the `annotate` "
 "command would not replace but extend the `.license` files with two "
 "additional lines stating the copyright of Max Mehl and the CC-BY-4.0 "
 "license. So you would have to update these manually."
 msgstr ""
 "La herramienta a partir de ahora no proporciona una forma de reemplazar la "
 "información existente de REUSE compatible de licencia y derechos de autor. "
-"Una ejecución del comando `addheader` no reemplazaría sino que ampliaría los "
+"Una ejecución del comando `annotate` no reemplazaría sino que ampliaría los "
 "archivos `.license` con dos líneas adicionales que indican los derechos de "
 "autor de Max Mehl y la licencia CC-BY-4.0. Por lo tanto, tendría que "
 "actualizarlos manualmente."
@@ -2876,21 +2876,21 @@ msgstr ""
 #. type: Plain text
 #: site/content/en/tutorial.md
 msgid ""
-"As before, a combination of the `addheader` and `download` commands will "
+"As before, a combination of the `annotate` and `download` commands will "
 "fulfil the above step:"
 msgstr ""
-"Como antes, una combinación de los comandos `addheader` y `download` "
+"Como antes, una combinación de los comandos `annotate` y `download` "
 "cumplirá el paso anterior:"
 
 #. type: Fenced code block (bash)
 #: site/content/en/tutorial.md
 #, no-wrap
 msgid ""
-"reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
+"reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
 "\n"
 "reuse download --all\n"
 msgstr ""
-"reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore \n"
+"reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore \n"
 " \n"
 "reuse download --all\n"
 

--- a/site/po/fr.po
+++ b/site/po/fr.po
@@ -2431,29 +2431,29 @@ msgstr ""
 #. type: Plain text
 #: site/content/en/tutorial.md
 msgid ""
-"The `reuse addheader` command helps with adding licensing and copyright "
+"The `reuse annotate` command helps with adding licensing and copyright "
 "information to your files. For the task above, the following command would "
 "do the job:"
 msgstr ""
-"La commande `reuse addheader` aide à ajouter des informations de licence et "
+"La commande `reuse annotate` aide à ajouter des informations de licence et "
 "de droit d'auteur à vos fichiers. Pour la tâche ci-dessus, la commande "
 "suivante ferait le travail :"
 
 #. type: Fenced code block (bash)
 #: site/content/en/tutorial.md
 #, no-wrap
-msgid "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
-msgstr "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
+msgstr "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
 
 #. type: Plain text
 #: site/content/en/tutorial.md
 msgid ""
-"Please see the [tool's documentation about addheader](https://reuse."
-"readthedocs.io/en/stable/usage.html#addheader)  for more options like "
+"Please see the [tool's documentation about annotate](https://reuse."
+"readthedocs.io/en/stable/usage.html#annotate)  for more options like "
 "comment styles and templates"
 msgstr ""
-"Veuillez consulter la [documentation de l'outil sur addheader](https://reuse."
-"readthedocs.io/en/stable/usage.html#addheader) pour plus d'options comme les "
+"Veuillez consulter la [documentation de l'outil sur annotate](https://reuse."
+"readthedocs.io/en/stable/usage.html#annotate) pour plus d'options comme les "
 "styles de commentaires et les modèles"
 
 #. type: Title ###
@@ -2503,23 +2503,23 @@ msgstr ""
 #, fuzzy
 #| msgid ""
 #| "If it does not, or if you would like to enforce this, add the `--explicit-"
-#| "license` argument to the addheader command. So the command for the above "
+#| "license` argument to the annotate command. So the command for the above "
 #| "task may look like this:"
 msgid ""
 "If it does not, or if you would like to enforce this, add the `--force-dot-"
-"license` argument to the addheader command. So the command for the above "
+"license` argument to the annotate command. So the command for the above "
 "task may look like this:"
 msgstr ""
 "Si ce n'est pas le cas, ou si vous souhaitez appliquer cela, ajoutez "
-"l'argument `--explicit-license` à la commande addheader. Ainsi, la commande "
+"l'argument `--explicit-license` à la commande annotate. Ainsi, la commande "
 "pour la tâche ci-dessus peut ressembler à ceci :"
 
 #. type: Fenced code block (bash)
 #: site/content/en/tutorial.md
 #, fuzzy, no-wrap
-#| msgid "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
-msgid "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --force-dot-license img/cat.jpg img/dog.jpg\n"
-msgstr "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
+#| msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --force-dot-license img/cat.jpg img/dog.jpg\n"
+msgstr "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
 
 #. type: Title ###
 #: site/content/en/tutorial.md
@@ -2571,14 +2571,14 @@ msgstr ""
 #: site/content/en/tutorial.md
 msgid ""
 "The tool as of now does not provide a way to replace existing REUSE-"
-"compliant copyright and licensing information. A run of the `addheader` "
+"compliant copyright and licensing information. A run of the `annotate` "
 "command would not replace but extend the `.license` files with two "
 "additional lines stating the copyright of Max Mehl and the CC-BY-4.0 "
 "license. So you would have to update these manually."
 msgstr ""
 "À l'heure actuelle, l'outil ne permet pas de remplacer les informations de "
 "copyright et de licence existantes conformes à REUSE. Une exécution de la "
-"commande `addheader` ne remplacerait pas mais étendrait les fichiers `."
+"commande `annotate` ne remplacerait pas mais étendrait les fichiers `."
 "license` avec deux lignes supplémentaires indiquant le copyright de Max Mehl "
 "et la licence CC-BY-4.0. Vous devrez donc les mettre à jour manuellement."
 
@@ -2683,21 +2683,21 @@ msgstr ""
 #. type: Plain text
 #: site/content/en/tutorial.md
 msgid ""
-"As before, a combination of the `addheader` and `download` commands will "
+"As before, a combination of the `annotate` and `download` commands will "
 "fulfil the above step:"
 msgstr ""
-"Comme précédemment, une combinaison des commandes `addheader` et `download` "
+"Comme précédemment, une combinaison des commandes `annotate` et `download` "
 "remplira l'étape ci-dessus :"
 
 #. type: Fenced code block (bash)
 #: site/content/en/tutorial.md
 #, no-wrap
 msgid ""
-"reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
+"reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
 "\n"
 "reuse download --all\n"
 msgstr ""
-"reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
+"reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
 "\n"
 "reuse download --all\n"
 

--- a/site/po/it.po
+++ b/site/po/it.po
@@ -1407,19 +1407,19 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "The `reuse addheader` command helps with adding licensing and copyright information to your files. For the task above, the following command would do the job:"
+msgid "The `reuse annotate` command helps with adding licensing and copyright information to your files. For the task above, the following command would do the job:"
 msgstr ""
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
-msgid "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
 msgstr ""
 
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "Please see the [tool's documentation about addheader](https://reuse.readthedocs.io/en/stable/usage.html#addheader)  for more options like comment styles and templates"
+msgid "Please see the [tool's documentation about annotate](https://reuse.readthedocs.io/en/stable/usage.html#annotate)  for more options like comment styles and templates"
 msgstr ""
 
 #. type: Title ###
@@ -1449,13 +1449,13 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "If it does not, or if you would like to enforce this, add the `--explicit-license` argument to the addheader command. So the command for the above task may look like this:"
+msgid "If it does not, or if you would like to enforce this, add the `--explicit-license` argument to the annotate command. So the command for the above task may look like this:"
 msgstr ""
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
-msgid "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
 msgstr ""
 
 #. type: Title ###
@@ -1494,7 +1494,7 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "The tool as of now does not provide a way to replace existing REUSE-compliant copyright and licensing information. A run of the `addheader` command would not replace but extend the `.license` files with two additional lines stating the copyright of Max Mehl and the CC-BY-4.0 license. So you would have to update these manually."
+msgid "The tool as of now does not provide a way to replace existing REUSE-compliant copyright and licensing information. A run of the `annotate` command would not replace but extend the `.license` files with two additional lines stating the copyright of Max Mehl and the CC-BY-4.0 license. So you would have to update these manually."
 msgstr ""
 
 #. type: Plain text
@@ -1559,14 +1559,14 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "As before, a combination of the `addheader` and `download` commands will fulfil the above step:"
+msgid "As before, a combination of the `annotate` and `download` commands will fulfil the above step:"
 msgstr ""
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
 msgid ""
-"reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
+"reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
 "\n"
 "reuse download --all\n"
 msgstr ""

--- a/site/po/nb_NO.po
+++ b/site/po/nb_NO.po
@@ -2042,7 +2042,7 @@ msgstr ""
 #. type: Plain text
 #: site/content/en/tutorial.md
 msgid ""
-"The `reuse addheader` command helps with adding licensing and copyright "
+"The `reuse annotate` command helps with adding licensing and copyright "
 "information to your files. For the task above, the following command would "
 "do the job:"
 msgstr ""
@@ -2050,14 +2050,14 @@ msgstr ""
 #. type: Fenced code block (bash)
 #: site/content/en/tutorial.md
 #, no-wrap
-msgid "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
 msgstr ""
 
 #. type: Plain text
 #: site/content/en/tutorial.md
 msgid ""
-"Please see the [tool's documentation about addheader](https://reuse."
-"readthedocs.io/en/stable/usage.html#addheader)  for more options like "
+"Please see the [tool's documentation about annotate](https://reuse."
+"readthedocs.io/en/stable/usage.html#annotate)  for more options like "
 "comment styles and templates"
 msgstr ""
 
@@ -2096,14 +2096,14 @@ msgstr ""
 #: site/content/en/tutorial.md
 msgid ""
 "If it does not, or if you would like to enforce this, add the `--force-dot-"
-"license` argument to the addheader command. So the command for the above "
+"license` argument to the annotate command. So the command for the above "
 "task may look like this:"
 msgstr ""
 
 #. type: Fenced code block (bash)
 #: site/content/en/tutorial.md
 #, no-wrap
-msgid "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --force-dot-license img/cat.jpg img/dog.jpg\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --force-dot-license img/cat.jpg img/dog.jpg\n"
 msgstr ""
 
 #. type: Title ###
@@ -2146,7 +2146,7 @@ msgstr ""
 #: site/content/en/tutorial.md
 msgid ""
 "The tool as of now does not provide a way to replace existing REUSE-"
-"compliant copyright and licensing information. A run of the `addheader` "
+"compliant copyright and licensing information. A run of the `annotate` "
 "command would not replace but extend the `.license` files with two "
 "additional lines stating the copyright of Max Mehl and the CC-BY-4.0 "
 "license. So you would have to update these manually."
@@ -2227,7 +2227,7 @@ msgstr ""
 #. type: Plain text
 #: site/content/en/tutorial.md
 msgid ""
-"As before, a combination of the `addheader` and `download` commands will "
+"As before, a combination of the `annotate` and `download` commands will "
 "fulfil the above step:"
 msgstr ""
 
@@ -2235,7 +2235,7 @@ msgstr ""
 #: site/content/en/tutorial.md
 #, no-wrap
 msgid ""
-"reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
+"reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
 "\n"
 "reuse download --all\n"
 msgstr ""

--- a/site/po/pt.po
+++ b/site/po/pt.po
@@ -2137,7 +2137,7 @@ msgstr ""
 #. type: Plain text
 #: site/content/en/tutorial.md
 msgid ""
-"The `reuse addheader` command helps with adding licensing and copyright "
+"The `reuse annotate` command helps with adding licensing and copyright "
 "information to your files. For the task above, the following command would "
 "do the job:"
 msgstr ""
@@ -2145,14 +2145,14 @@ msgstr ""
 #. type: Fenced code block (bash)
 #: site/content/en/tutorial.md
 #, no-wrap
-msgid "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
 msgstr ""
 
 #. type: Plain text
 #: site/content/en/tutorial.md
 msgid ""
-"Please see the [tool's documentation about addheader](https://reuse."
-"readthedocs.io/en/stable/usage.html#addheader)  for more options like "
+"Please see the [tool's documentation about annotate](https://reuse."
+"readthedocs.io/en/stable/usage.html#annotate)  for more options like "
 "comment styles and templates"
 msgstr ""
 
@@ -2191,14 +2191,14 @@ msgstr ""
 #: site/content/en/tutorial.md
 msgid ""
 "If it does not, or if you would like to enforce this, add the `--force-dot-"
-"license` argument to the addheader command. So the command for the above "
+"license` argument to the annotate command. So the command for the above "
 "task may look like this:"
 msgstr ""
 
 #. type: Fenced code block (bash)
 #: site/content/en/tutorial.md
 #, no-wrap
-msgid "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --force-dot-license img/cat.jpg img/dog.jpg\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --force-dot-license img/cat.jpg img/dog.jpg\n"
 msgstr ""
 
 #. type: Title ###
@@ -2241,7 +2241,7 @@ msgstr ""
 #: site/content/en/tutorial.md
 msgid ""
 "The tool as of now does not provide a way to replace existing REUSE-"
-"compliant copyright and licensing information. A run of the `addheader` "
+"compliant copyright and licensing information. A run of the `annotate` "
 "command would not replace but extend the `.license` files with two "
 "additional lines stating the copyright of Max Mehl and the CC-BY-4.0 "
 "license. So you would have to update these manually."
@@ -2322,7 +2322,7 @@ msgstr ""
 #. type: Plain text
 #: site/content/en/tutorial.md
 msgid ""
-"As before, a combination of the `addheader` and `download` commands will "
+"As before, a combination of the `annotate` and `download` commands will "
 "fulfil the above step:"
 msgstr ""
 
@@ -2330,7 +2330,7 @@ msgstr ""
 #: site/content/en/tutorial.md
 #, no-wrap
 msgid ""
-"reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
+"reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
 "\n"
 "reuse download --all\n"
 msgstr ""

--- a/site/po/pt_BR.po
+++ b/site/po/pt_BR.po
@@ -2152,7 +2152,7 @@ msgstr ""
 #. type: Plain text
 #: site/content/en/tutorial.md
 msgid ""
-"The `reuse addheader` command helps with adding licensing and copyright "
+"The `reuse annotate` command helps with adding licensing and copyright "
 "information to your files. For the task above, the following command would "
 "do the job:"
 msgstr ""
@@ -2160,14 +2160,14 @@ msgstr ""
 #. type: Fenced code block (bash)
 #: site/content/en/tutorial.md
 #, no-wrap
-msgid "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
 msgstr ""
 
 #. type: Plain text
 #: site/content/en/tutorial.md
 msgid ""
-"Please see the [tool's documentation about addheader](https://reuse."
-"readthedocs.io/en/stable/usage.html#addheader)  for more options like "
+"Please see the [tool's documentation about annotate](https://reuse."
+"readthedocs.io/en/stable/usage.html#annotate)  for more options like "
 "comment styles and templates"
 msgstr ""
 
@@ -2206,14 +2206,14 @@ msgstr ""
 #: site/content/en/tutorial.md
 msgid ""
 "If it does not, or if you would like to enforce this, add the `--force-dot-"
-"license` argument to the addheader command. So the command for the above "
+"license` argument to the annotate command. So the command for the above "
 "task may look like this:"
 msgstr ""
 
 #. type: Fenced code block (bash)
 #: site/content/en/tutorial.md
 #, no-wrap
-msgid "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --force-dot-license img/cat.jpg img/dog.jpg\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --force-dot-license img/cat.jpg img/dog.jpg\n"
 msgstr ""
 
 #. type: Title ###
@@ -2256,7 +2256,7 @@ msgstr ""
 #: site/content/en/tutorial.md
 msgid ""
 "The tool as of now does not provide a way to replace existing REUSE-"
-"compliant copyright and licensing information. A run of the `addheader` "
+"compliant copyright and licensing information. A run of the `annotate` "
 "command would not replace but extend the `.license` files with two "
 "additional lines stating the copyright of Max Mehl and the CC-BY-4.0 "
 "license. So you would have to update these manually."
@@ -2337,7 +2337,7 @@ msgstr ""
 #. type: Plain text
 #: site/content/en/tutorial.md
 msgid ""
-"As before, a combination of the `addheader` and `download` commands will "
+"As before, a combination of the `annotate` and `download` commands will "
 "fulfil the above step:"
 msgstr ""
 
@@ -2345,7 +2345,7 @@ msgstr ""
 #: site/content/en/tutorial.md
 #, no-wrap
 msgid ""
-"reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
+"reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
 "\n"
 "reuse download --all\n"
 msgstr ""

--- a/site/po/reuse-website.pot
+++ b/site/po/reuse-website.pot
@@ -2252,7 +2252,7 @@ msgstr ""
 #: site/content/en/tutorial.md
 #, markdown-text
 msgid ""
-"The `reuse addheader` command helps with adding licensing and copyright "
+"The `reuse annotate` command helps with adding licensing and copyright "
 "information to your files. For the task above, the following command would "
 "do the job:"
 msgstr ""
@@ -2261,7 +2261,7 @@ msgstr ""
 #: site/content/en/tutorial.md
 #, no-wrap
 msgid ""
-"reuse addheader --copyright=\"Jane Doe <jane@example.com>\" "
+"reuse annotate --copyright=\"Jane Doe <jane@example.com>\" "
 "--license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
 msgstr ""
 
@@ -2270,7 +2270,7 @@ msgstr ""
 #, markdown-text
 msgid ""
 "Please see the [tool's documentation about "
-"addheader](https://reuse.readthedocs.io/en/stable/usage.html#addheader)  for "
+"annotate](https://reuse.readthedocs.io/en/stable/usage.html#annotate)  for "
 "more options like comment styles and templates"
 msgstr ""
 
@@ -2313,7 +2313,7 @@ msgstr ""
 #, markdown-text
 msgid ""
 "If it does not, or if you would like to enforce this, add the "
-"`--force-dot-license` argument to the addheader command. So the command for "
+"`--force-dot-license` argument to the annotate command. So the command for "
 "the above task may look like this:"
 msgstr ""
 
@@ -2321,7 +2321,7 @@ msgstr ""
 #: site/content/en/tutorial.md
 #, no-wrap
 msgid ""
-"reuse addheader --copyright=\"Jane Doe <jane@example.com>\" "
+"reuse annotate --copyright=\"Jane Doe <jane@example.com>\" "
 "--license=\"GPL-3.0-or-later\" --force-dot-license img/cat.jpg img/dog.jpg\n"
 msgstr ""
 
@@ -2370,7 +2370,7 @@ msgstr ""
 msgid ""
 "The tool as of now does not provide a way to replace existing "
 "REUSE-compliant copyright and licensing information. A run of the "
-"`addheader` command would not replace but extend the `.license` files with "
+"`annotate` command would not replace but extend the `.license` files with "
 "two additional lines stating the copyright of Max Mehl and the CC-BY-4.0 "
 "license. So you would have to update these manually."
 msgstr ""
@@ -2458,7 +2458,7 @@ msgstr ""
 #: site/content/en/tutorial.md
 #, markdown-text
 msgid ""
-"As before, a combination of the `addheader` and `download` commands will "
+"As before, a combination of the `annotate` and `download` commands will "
 "fulfil the above step:"
 msgstr ""
 
@@ -2466,7 +2466,7 @@ msgstr ""
 #: site/content/en/tutorial.md
 #, no-wrap
 msgid ""
-"reuse addheader --copyright=\"Jane Doe <jane@example.com>\" "
+"reuse annotate --copyright=\"Jane Doe <jane@example.com>\" "
 "--license=\"CC0-1.0\" .gitignore\n"
 "\n"
 "reuse download --all\n"

--- a/site/po/ru.po
+++ b/site/po/ru.po
@@ -1805,28 +1805,28 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "The `reuse addheader` command helps with adding licensing and copyright information to your files. For the task above, the following command would do the job:"
+msgid "The `reuse annotate` command helps with adding licensing and copyright information to your files. For the task above, the following command would do the job:"
 msgstr ""
-"Команда `reuse addheader` помогает добавить в файлы информацию о "
+"Команда `reuse annotate` помогает добавить в файлы информацию о "
 "лицензировании и авторских правах. Для приведенной выше задачи подойдет "
 "следующая команда:"
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
-msgid "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
 msgstr ""
-"reuse addheader --copyright=\" Джейн Доу <jane@example.com>\" --license=\"GPL"
+"reuse annotate --copyright=\" Джейн Доу <jane@example.com>\" --license=\"GPL"
 "-3.0-or-later\" src/main.c Makefile README.md\n"
 
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "Please see the [tool's documentation about addheader](https://reuse.readthedocs.io/en/stable/usage.html#addheader)  for more options like comment styles and templates"
+msgid "Please see the [tool's documentation about annotate](https://reuse.readthedocs.io/en/stable/usage.html#annotate)  for more options like comment styles and templates"
 msgstr ""
 "Дополнительные возможности, такие как стили и шаблоны комментариев, см. в ["
-"документации по инструменту addheader](https://reuse.readthedocs.io/en/"
-"stable/usage.html#addheader)"
+"документации по инструменту annotate](https://reuse.readthedocs.io/en/"
+"stable/usage.html#annotate)"
 
 #. type: Title ###
 #: tutorial.md
@@ -1865,18 +1865,18 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "If it does not, or if you would like to enforce this, add the `--explicit-license` argument to the addheader command. So the command for the above task may look like this:"
+msgid "If it does not, or if you would like to enforce this, add the `--explicit-license` argument to the annotate command. So the command for the above task may look like this:"
 msgstr ""
 "Если это не так, или если вы хотите обеспечить это, добавьте аргумент "
-"`--explicit-license` к команде addheader. Таким образом, команда для "
+"`--explicit-license` к команде annotate. Таким образом, команда для "
 "приведенной выше задачи может выглядеть следующим образом:"
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
-msgid "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
 msgstr ""
-"reuse addheader --copyright=\" Джейн Доу <jane@example.com>\" --license=\"GPL"
+"reuse annotate --copyright=\" Джейн Доу <jane@example.com>\" --license=\"GPL"
 "-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
 
 #. type: Title ###
@@ -1925,11 +1925,11 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "The tool as of now does not provide a way to replace existing REUSE-compliant copyright and licensing information. A run of the `addheader` command would not replace but extend the `.license` files with two additional lines stating the copyright of Max Mehl and the CC-BY-4.0 license. So you would have to update these manually."
+msgid "The tool as of now does not provide a way to replace existing REUSE-compliant copyright and licensing information. A run of the `annotate` command would not replace but extend the `.license` files with two additional lines stating the copyright of Max Mehl and the CC-BY-4.0 license. So you would have to update these manually."
 msgstr ""
 "На данный момент инструмент не предоставляет возможности заменить "
 "существующую информацию об авторских правах и лицензировании, "
-"соответствующую REUSE. Выполнение команды `addheader` не заменит, а расширит "
+"соответствующую REUSE. Выполнение команды `annotate` не заменит, а расширит "
 "файлы `.license` двумя дополнительными строками, указывающими авторские "
 "права Макса Меля и лицензию CC-BY-4.0. Поэтому вам придется обновить их "
 "вручную."
@@ -2021,20 +2021,20 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "As before, a combination of the `addheader` and `download` commands will fulfil the above step:"
+msgid "As before, a combination of the `annotate` and `download` commands will fulfil the above step:"
 msgstr ""
-"Как и раньше, комбинация команд `addheader` и `download` выполнит описанный "
+"Как и раньше, комбинация команд `annotate` и `download` выполнит описанный "
 "выше шаг:"
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
 msgid ""
-"reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
+"reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
 "\n"
 "reuse download --all\n"
 msgstr ""
-"reuse addheader --copyright=\" Джейн Доу <jane@example.com>\" --лицензия="
+"reuse annotate --copyright=\" Джейн Доу <jane@example.com>\" --лицензия="
 "\"CC0-1.0\" .gitignore\n"
 "\n"
 "reuse download --all\n"

--- a/site/po/sv.po
+++ b/site/po/sv.po
@@ -2052,7 +2052,7 @@ msgstr ""
 #. type: Plain text
 #: site/content/en/tutorial.md
 msgid ""
-"The `reuse addheader` command helps with adding licensing and copyright "
+"The `reuse annotate` command helps with adding licensing and copyright "
 "information to your files. For the task above, the following command would "
 "do the job:"
 msgstr ""
@@ -2060,14 +2060,14 @@ msgstr ""
 #. type: Fenced code block (bash)
 #: site/content/en/tutorial.md
 #, no-wrap
-msgid "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
 msgstr ""
 
 #. type: Plain text
 #: site/content/en/tutorial.md
 msgid ""
-"Please see the [tool's documentation about addheader](https://reuse."
-"readthedocs.io/en/stable/usage.html#addheader)  for more options like "
+"Please see the [tool's documentation about annotate](https://reuse."
+"readthedocs.io/en/stable/usage.html#annotate)  for more options like "
 "comment styles and templates"
 msgstr ""
 
@@ -2106,14 +2106,14 @@ msgstr ""
 #: site/content/en/tutorial.md
 msgid ""
 "If it does not, or if you would like to enforce this, add the `--force-dot-"
-"license` argument to the addheader command. So the command for the above "
+"license` argument to the annotate command. So the command for the above "
 "task may look like this:"
 msgstr ""
 
 #. type: Fenced code block (bash)
 #: site/content/en/tutorial.md
 #, no-wrap
-msgid "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --force-dot-license img/cat.jpg img/dog.jpg\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --force-dot-license img/cat.jpg img/dog.jpg\n"
 msgstr ""
 
 #. type: Title ###
@@ -2156,7 +2156,7 @@ msgstr ""
 #: site/content/en/tutorial.md
 msgid ""
 "The tool as of now does not provide a way to replace existing REUSE-"
-"compliant copyright and licensing information. A run of the `addheader` "
+"compliant copyright and licensing information. A run of the `annotate` "
 "command would not replace but extend the `.license` files with two "
 "additional lines stating the copyright of Max Mehl and the CC-BY-4.0 "
 "license. So you would have to update these manually."
@@ -2237,7 +2237,7 @@ msgstr ""
 #. type: Plain text
 #: site/content/en/tutorial.md
 msgid ""
-"As before, a combination of the `addheader` and `download` commands will "
+"As before, a combination of the `annotate` and `download` commands will "
 "fulfil the above step:"
 msgstr ""
 
@@ -2245,7 +2245,7 @@ msgstr ""
 #: site/content/en/tutorial.md
 #, no-wrap
 msgid ""
-"reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
+"reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
 "\n"
 "reuse download --all\n"
 msgstr ""

--- a/site/po/tr.po
+++ b/site/po/tr.po
@@ -2214,7 +2214,7 @@ msgstr ""
 #. type: Plain text
 #: site/content/en/tutorial.md
 msgid ""
-"The `reuse addheader` command helps with adding licensing and copyright "
+"The `reuse annotate` command helps with adding licensing and copyright "
 "information to your files. For the task above, the following command would "
 "do the job:"
 msgstr ""
@@ -2222,14 +2222,14 @@ msgstr ""
 #. type: Fenced code block (bash)
 #: site/content/en/tutorial.md
 #, no-wrap
-msgid "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
 msgstr ""
 
 #. type: Plain text
 #: site/content/en/tutorial.md
 msgid ""
-"Please see the [tool's documentation about addheader](https://reuse."
-"readthedocs.io/en/stable/usage.html#addheader)  for more options like "
+"Please see the [tool's documentation about annotate](https://reuse."
+"readthedocs.io/en/stable/usage.html#annotate)  for more options like "
 "comment styles and templates"
 msgstr ""
 
@@ -2268,14 +2268,14 @@ msgstr ""
 #: site/content/en/tutorial.md
 msgid ""
 "If it does not, or if you would like to enforce this, add the `--force-dot-"
-"license` argument to the addheader command. So the command for the above "
+"license` argument to the annotate command. So the command for the above "
 "task may look like this:"
 msgstr ""
 
 #. type: Fenced code block (bash)
 #: site/content/en/tutorial.md
 #, no-wrap
-msgid "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --force-dot-license img/cat.jpg img/dog.jpg\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --force-dot-license img/cat.jpg img/dog.jpg\n"
 msgstr ""
 
 #. type: Title ###
@@ -2318,7 +2318,7 @@ msgstr ""
 #: site/content/en/tutorial.md
 msgid ""
 "The tool as of now does not provide a way to replace existing REUSE-"
-"compliant copyright and licensing information. A run of the `addheader` "
+"compliant copyright and licensing information. A run of the `annotate` "
 "command would not replace but extend the `.license` files with two "
 "additional lines stating the copyright of Max Mehl and the CC-BY-4.0 "
 "license. So you would have to update these manually."
@@ -2399,7 +2399,7 @@ msgstr ""
 #. type: Plain text
 #: site/content/en/tutorial.md
 msgid ""
-"As before, a combination of the `addheader` and `download` commands will "
+"As before, a combination of the `annotate` and `download` commands will "
 "fulfil the above step:"
 msgstr ""
 
@@ -2407,7 +2407,7 @@ msgstr ""
 #: site/content/en/tutorial.md
 #, no-wrap
 msgid ""
-"reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
+"reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
 "\n"
 "reuse download --all\n"
 msgstr ""

--- a/site/po/uk.po
+++ b/site/po/uk.po
@@ -2587,29 +2587,29 @@ msgstr ""
 #. type: Plain text
 #: site/content/en/tutorial.md
 msgid ""
-"The `reuse addheader` command helps with adding licensing and copyright "
+"The `reuse annotate` command helps with adding licensing and copyright "
 "information to your files. For the task above, the following command would "
 "do the job:"
 msgstr ""
-"Команда `reuse addheader` допомагає додавати відомості про ліцензії та "
+"Команда `reuse annotate` допомагає додавати відомості про ліцензії та "
 "авторські права до ваших файлів. Для завдання вище, така команда "
 "виконуватиме цю роботу:"
 
 #. type: Fenced code block (bash)
 #: site/content/en/tutorial.md
 #, no-wrap
-msgid "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
-msgstr "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
+msgstr "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
 
 #. type: Plain text
 #: site/content/en/tutorial.md
 msgid ""
-"Please see the [tool's documentation about addheader](https://reuse."
-"readthedocs.io/en/stable/usage.html#addheader)  for more options like "
+"Please see the [tool's documentation about annotate](https://reuse."
+"readthedocs.io/en/stable/usage.html#annotate)  for more options like "
 "comment styles and templates"
 msgstr ""
-"Перегляньте [документацію засобу про addheader](https://reuse.readthedocs.io/"
-"en/stable/usage.html#addheader), щоб дізнатися про додаткові опції, як-от "
+"Перегляньте [документацію засобу про annotate](https://reuse.readthedocs.io/"
+"en/stable/usage.html#annotate), щоб дізнатися про додаткові опції, як-от "
 "стилі коментарів і шаблони"
 
 #. type: Title ###
@@ -2657,23 +2657,23 @@ msgstr ""
 #, fuzzy
 #| msgid ""
 #| "If it does not, or if you would like to enforce this, add the `--explicit-"
-#| "license` argument to the addheader command. So the command for the above "
+#| "license` argument to the annotate command. So the command for the above "
 #| "task may look like this:"
 msgid ""
 "If it does not, or if you would like to enforce this, add the `--force-dot-"
-"license` argument to the addheader command. So the command for the above "
+"license` argument to the annotate command. So the command for the above "
 "task may look like this:"
 msgstr ""
 "Якщо цього не сталося, або якщо ви хочете примусово застосувати це, додайте "
-"аргумент `--explicit-license` до команди addheader. Отже, команда для "
+"аргумент `--explicit-license` до команди annotate. Отже, команда для "
 "вищезазначеного завдання може мати такий вигляд:"
 
 #. type: Fenced code block (bash)
 #: site/content/en/tutorial.md
 #, fuzzy, no-wrap
-#| msgid "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
-msgid "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --force-dot-license img/cat.jpg img/dog.jpg\n"
-msgstr "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
+#| msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --force-dot-license img/cat.jpg img/dog.jpg\n"
+msgstr "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
 
 #. type: Title ###
 #: site/content/en/tutorial.md
@@ -2724,13 +2724,13 @@ msgstr ""
 #: site/content/en/tutorial.md
 msgid ""
 "The tool as of now does not provide a way to replace existing REUSE-"
-"compliant copyright and licensing information. A run of the `addheader` "
+"compliant copyright and licensing information. A run of the `annotate` "
 "command would not replace but extend the `.license` files with two "
 "additional lines stating the copyright of Max Mehl and the CC-BY-4.0 "
 "license. So you would have to update these manually."
 msgstr ""
 "Наразі засіб не надає способу заміни наявних відомостей про авторські права "
-"та ліцензування, сумісних з REUSE. Запуск команди `addheader` не замінить, а "
+"та ліцензування, сумісних з REUSE. Запуск команди `annotate` не замінить, а "
 "розширить файли `.license` двома додатковими рядками із зазначенням "
 "авторських прав Макса Мела та ліцензії CC-BY-4.0. Таким чином, вам потрібно "
 "оновити їх вручну."
@@ -2833,21 +2833,21 @@ msgstr ""
 #. type: Plain text
 #: site/content/en/tutorial.md
 msgid ""
-"As before, a combination of the `addheader` and `download` commands will "
+"As before, a combination of the `annotate` and `download` commands will "
 "fulfil the above step:"
 msgstr ""
-"Як і раніше, комбінація команд `addheader` and `download` виконає наведену "
+"Як і раніше, комбінація команд `annotate` and `download` виконає наведену "
 "раніше дію:"
 
 #. type: Fenced code block (bash)
 #: site/content/en/tutorial.md
 #, no-wrap
 msgid ""
-"reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
+"reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
 "\n"
 "reuse download --all\n"
 msgstr ""
-"reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
+"reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
 "\n"
 "reuse download --all\n"
 

--- a/site/po/zh_Hans.po
+++ b/site/po/zh_Hans.po
@@ -2055,7 +2055,7 @@ msgstr ""
 #. type: Plain text
 #: site/content/en/tutorial.md
 msgid ""
-"The `reuse addheader` command helps with adding licensing and copyright "
+"The `reuse annotate` command helps with adding licensing and copyright "
 "information to your files. For the task above, the following command would "
 "do the job:"
 msgstr ""
@@ -2063,14 +2063,14 @@ msgstr ""
 #. type: Fenced code block (bash)
 #: site/content/en/tutorial.md
 #, no-wrap
-msgid "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
 msgstr ""
 
 #. type: Plain text
 #: site/content/en/tutorial.md
 msgid ""
-"Please see the [tool's documentation about addheader](https://reuse."
-"readthedocs.io/en/stable/usage.html#addheader)  for more options like "
+"Please see the [tool's documentation about annotate](https://reuse."
+"readthedocs.io/en/stable/usage.html#annotate)  for more options like "
 "comment styles and templates"
 msgstr ""
 
@@ -2109,14 +2109,14 @@ msgstr ""
 #: site/content/en/tutorial.md
 msgid ""
 "If it does not, or if you would like to enforce this, add the `--force-dot-"
-"license` argument to the addheader command. So the command for the above "
+"license` argument to the annotate command. So the command for the above "
 "task may look like this:"
 msgstr ""
 
 #. type: Fenced code block (bash)
 #: site/content/en/tutorial.md
 #, no-wrap
-msgid "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --force-dot-license img/cat.jpg img/dog.jpg\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --force-dot-license img/cat.jpg img/dog.jpg\n"
 msgstr ""
 
 #. type: Title ###
@@ -2159,7 +2159,7 @@ msgstr ""
 #: site/content/en/tutorial.md
 msgid ""
 "The tool as of now does not provide a way to replace existing REUSE-"
-"compliant copyright and licensing information. A run of the `addheader` "
+"compliant copyright and licensing information. A run of the `annotate` "
 "command would not replace but extend the `.license` files with two "
 "additional lines stating the copyright of Max Mehl and the CC-BY-4.0 "
 "license. So you would have to update these manually."
@@ -2240,7 +2240,7 @@ msgstr ""
 #. type: Plain text
 #: site/content/en/tutorial.md
 msgid ""
-"As before, a combination of the `addheader` and `download` commands will "
+"As before, a combination of the `annotate` and `download` commands will "
 "fulfil the above step:"
 msgstr ""
 
@@ -2248,7 +2248,7 @@ msgstr ""
 #: site/content/en/tutorial.md
 #, no-wrap
 msgid ""
-"reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
+"reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
 "\n"
 "reuse download --all\n"
 msgstr ""


### PR DESCRIPTION
The site still referenced the addheader command which has been deprecated.

- Updated references to `addHeader` using the new `annotate` command
- Fixed the link to the documentation 