### PR TITLE
Specification button points to latest spec again

### DIFF
--- a/site/config.toml
+++ b/site/config.toml
@@ -86,7 +86,7 @@ defaultContentLanguageInSubdir = true
 [[menu.main]]
   identifier = "spec"
   weight = 300
-  url = "/specifications/"
+  url = "/spec/"
 [[menu.main]]
   identifier = "resources"
   weight = 500

--- a/site/content/en/specifications.md
+++ b/site/content/en/specifications.md
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: 2024 Free Software Foundation Europe e.V.
 # SPDX-License-Identifier: CC-BY-SA-4.0
 
-title: "REUSE Specification"
+title: "REUSE Specifications"
 ---
 
 These are the versions of the specification, listed from new to old:

--- a/site/i18n/en.json
+++ b/site/i18n/en.json
@@ -79,5 +79,8 @@
   },
   "index_legal_text": {
     "other": "There are many tools that aid you in license compliance for software, many using databases and fuzzy heuristics. A REUSE-compliant project makes the jobs of legal experts and compliance officers much easier. Creating a bill of materials can be achieved with just one simple command. REUSE [does not replace other tools](comparison/), it is a long-awaited addition."
+  },
+  "all_specifications": {
+    "other": "All versions of the specification can be found at <{{ .specifications }}>."
   }
 }

--- a/site/layouts/_default/single.html
+++ b/site/layouts/_default/single.html
@@ -8,6 +8,11 @@
 {{ partial "nav.html" . }}
 <div class="content">
   <div class="clearfix"></div>
+  {{- $filepath := "/" }}
+  {{- with .File }}{{- with .Path }}{{ $filepath = . }}{{ end }}{{ end }}
+  {{ if hasPrefix $filepath "spec-" }}
+    {{ partial "specifications.html" . }}
+  {{ end }}
   <h1>{{ .Page.Title }}</h1>
   {{ if .Params.subtitle }}<h2 class="subtitle">{{ .Params.subtitle }}</h2>{{ end }}
   {{ partial "translation.html" . }}

--- a/site/layouts/partials/specifications.html
+++ b/site/layouts/partials/specifications.html
@@ -1,0 +1,8 @@
+<!--
+     SPDX-License-Identifier: MIT
+     SPDX-FileCopyrightText: 2024 Free Software Foundation Europe e.V. <https://fsfe.org>
+-->
+<div class="alert alert-info">
+    {{ $specURL := ref . "/specifications" }}
+    {{ i18n "all_specifications" (dict "specifications" $specURL) | markdownify }}
+</div>


### PR DESCRIPTION
Now, to get a list of all specifications, an info box appears above every specification that takes you to the /specifications page.

Screenshots:

![Capture d’écran du 2024-06-24 11-25-34](https://github.com/fsfe/reuse-website/assets/12065945/83a80a84-5db3-4d10-95a7-06dc023ad2f1)
![Capture d’écran du 2024-06-24 11-25-43](https://github.com/fsfe/reuse-website/assets/12065945/034f7588-6ed9-4b77-8d85-da6ac2348f3f)