### PR TITLE
Fix redirect to use English-language version

### DIFF
--- a/site/config.toml
+++ b/site/config.toml
@@ -43,6 +43,8 @@ refLinksErrorLevel = "warning"
     header_link_color="#777"
     header_link_hover_color="rgb(51, 51, 51)"
 
+    current_spec="spec-3.2"
+
 [params.social]
   Github        = "search?q=topic%3Areuse+org%3Afsfe&type=Repositories"
   Git           = "https://git.fsfe.org/reuse"

--- a/site/content/en/spec-3.2.md
+++ b/site/content/en/spec-3.2.md
@@ -6,8 +6,6 @@
 
 title: "REUSE Specification – Version 3.2"
 subtitle: "2024-07-03"
-aliases: 
-  - "/spec"
 ---
 
 This specification defines a standardised method for declaring copyright and

--- a/site/content/en/spec.md
+++ b/site/content/en/spec.md
@@ -1,0 +1,7 @@
+---
+# SPDX-FileCopyrightText: 2024 Free Software Foundation Europe e.V.
+# SPDX-License-Identifier: MIT
+
+title: "REUSE Specification"
+layout: "redirect_current_spec"
+---

--- a/site/layouts/_default/redirect_current_spec.html
+++ b/site/layouts/_default/redirect_current_spec.html
@@ -1,0 +1,14 @@
+<!--
+     SPDX-License-Identifier: MIT
+     SPDX-FileCopyrightText: 2024 Free Software Foundation Europe e.V. <https://fsfe.org>
+-->
+
+<html lang="en">
+  <head>
+      <title>REUSE Specification</title>
+      <link rel="canonical" href="/{{ .Site.Params.current_spec }}/">
+      <meta name="robots" content="noindex">
+      <meta charset="utf-8">
+      <meta http-equiv="refresh" content="0; url=/{{ .Site.Params.current_spec }}/">
+  </head>
+</html>


### PR DESCRIPTION
The problem: Sometimes, when Hugo generated the website, the `/spec/` alias would point to the Ukrainian translation of the latest specification. Exactly how or why this happens is unclear to me, but I suspect it is because the Ukrainian Markdown file would also contain the `aliases: ["/spec"]` frontmatter, and the Hugo compiler would somehow toss a coin on which aliases frontmatter is authoritative.

Here, we get rid of the frontmatter method of doing aliases, and instead use a 'layout' to effectively do the same thing.