### PR TITLE
FAQ: Fix dead link to old SPDX spec.

### DIFF
--- a/site/content/en/faq.md
+++ b/site/content/en/faq.md
@@ -348,7 +348,7 @@ $ reuse --help
 
 Install the reuse tool and run `reuse spdx -o reuse.spdx` in the project root
 to create an [SPDX
-document](https://spdx.org/spdx-specification-21-web-version).
+document](https://spdx.dev/use/specifications/).
 
 ## ... add copyright and licensing information to an uncommentable file? {#uncommentable-file}
 


### PR DESCRIPTION
As the title states: Fixed a dead link to SPDX documents.

Question: There are also several dead links to this resource in translations files:

```bash
~/dev/reuse-website$ grep "spdx-specification-21-web-version" -r -l
site/po/cs.po
site/po/es.po
site/po/fr.po
site/po/it.po
site/po/reuse-website.pot
site/po/ru.po
```
especially referencing  

> SPDX Specification, Appendix IV, <https://spdx.org/spdx-specification-21-web-version#h.jxpfx0ykyb60>

which should be replaced by

> SPDX Specification, Annex D, <https://spdx.github.io/spdx-spec/v2.3/SPDX-license-expressions/>

Is it OK to edit these `.po` files directly? (I've never used GNU gettext myself, so this might be a dumb question.) If yes, I could add an addition commit to the PR. :)