### PR TITLE
Remove link loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,9 @@ similar! You will find this and more developer tools
 
 ## Contribute
 
-We welcome your pull requests and issue reports. Please be aware that
-this repository does not contain the specification, tutorial, and FAQ,
-so please direct your inquiry to [reuse
-docs](https://github.com/fsfe/reuse-docs).
+We welcome your pull requests and issue reports. This repository does
+contain the website, and also the specification, tutorial and FAQ 
+documents.
 
 Generally, we invite you to contact and join the [REUSE mailing
 list](https://lists.fsfe.org/mailman/listinfo/reuse).


### PR DESCRIPTION
- Previously, the "Contribute" section has included a notice that the specs, FAQ and tutorial live in a different repository.
- This other repository has now been archived and directs users to this repository.
- This patch changes the respective text in the README and removes the link to the archived repository.