### PR TITLE
refactor: switch deprecated GetJSON with native functions

### DIFF
--- a/site/layouts/partials/footer-orgs.html
+++ b/site/layouts/partials/footer-orgs.html
@@ -2,7 +2,9 @@
   SPDX-License-Identifier: MIT
   SPDX-FileCopyrightText: 2020 Free Software Foundation Europe e.V. <https://fsfe.org>
 -->
-{{ $orgs := where (getJSON "data/organisations.json") "footer" true }}
+{{ $data := readFile "data/organisations.json" }}
+{{ $unmarshaled := $data | unmarshal }}
+{{ $orgs := where $unmarshaled "footer" true }}
 {{ $img := "" }}
 <div class="orgs">
   <p class="text-muted">Selected supporters and adopters:</p>

--- a/site/layouts/shortcodes/supporters.html
+++ b/site/layouts/shortcodes/supporters.html
@@ -2,7 +2,9 @@
   SPDX-License-Identifier: MIT
   SPDX-FileCopyrightText: 2020 Free Software Foundation Europe e.V. <https://fsfe.org>
 -->
-{{ $orgs := where (getJSON "data/organisations.json") "sponsor" true }}
+{{ $data := readFile "data/organisations.json" }}
+{{ $unmarshaled := $data | unmarshal }}
+{{ $orgs := where $unmarshaled "sponsor" true }}
 <div class="table-responsive">
   <table class="table table-striped supporters">
     <tbody>


### PR DESCRIPTION
It uses several steps to filter by content
1. It gets the resource
2. Accesses the .Content property
3. unmarshals it and filters based on footer or sponsor